### PR TITLE
Fix FCHOICE bits being wrong in init() method

### DIFF
--- a/src/MPU9255.cpp
+++ b/src/MPU9255.cpp
@@ -28,10 +28,10 @@ uint8_t MPU9255::init()
 {
   Wire.begin();//enable I2C interface
   Hreset();//reset the chip
-  write(MPU_address,CONFIG, 0x03); // set DLPF_CFG to 11
-  write(MPU_address,SMPLRT_DIV, 0x00);// set prescaler sample rate to 0
-  write(MPU_address,GYRO_CONFIG, 0x01);// set gyro to 3.6 KHz bandwidth, and 0.11 ms using FCHOICE bits
-  write(MPU_address,INT_PIN_CFG, 0x02);// enable bypass
+  write(MPU_address,CONFIG, 0x03);//set DLPF_CFG to 0b11
+  write(MPU_address,SMPLRT_DIV, 0x00);//set prescaler sample rate to 0
+  write(MPU_address,GYRO_CONFIG, 0x02);//set gyro to 3.6 kHz bandwidth, and 0.11 ms using FCHOICE_B=0b10 (i.e. FCHOICE=0b01)
+  write(MPU_address,INT_PIN_CFG, 0x02);//enable bypass
   write(MAG_address, CNTL, 0x16);//set magnetometer to read in mode 2 and enable 16 bit measurements
 
   //read magnetometer sensitivity
@@ -57,7 +57,7 @@ uint8_t MPU9255::init()
   AY_offset = AY_offset>>1;
   AZ_offset = AZ_offset>>1;
 
-  return (testIMU() || testMag());//return the output
+  return (testIMU() || testMag());// return the output
 }
 
 /**


### PR DESCRIPTION
According to the datasheet, the inverse of FCHOICE must be written to the gyro register. The style of the comments in the init() method was also matched to the style of the other comments in the MPU9255.cpp file.

![image](https://user-images.githubusercontent.com/24859764/109532200-c9003980-7ab0-11eb-951a-61268c4b7775.png)
